### PR TITLE
Added default tokenPath and fixed SingleDocExtraction Example

### DIFF
--- a/Indico/IndicoConfig.cs
+++ b/Indico/IndicoConfig.cs
@@ -43,7 +43,7 @@ namespace Indico
             {
                 if (tokenPath == null)
                 {
-                    throw new RuntimeException("apiToken or tokenPath is missing");
+                    tokenPath = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
                 }
                 this.ApiToken = this.ResolveApiToken(tokenPath).Result;
             }
@@ -61,7 +61,18 @@ namespace Indico
         private async Task<string> ResolveApiToken(string path)
         {
             string apiToken;
-            string absolutePath = Path.Combine(path, "indico_api_token.txt");
+            string absolutePath;
+            const string ApiTokenFile = "indico_api_token.txt";
+
+            if (path.EndsWith(ApiTokenFile))
+            {
+                absolutePath = path;
+            }
+            else
+            {
+                absolutePath = Path.Combine(path, ApiTokenFile);
+            }
+            
             if (File.Exists(absolutePath))
             {
                 FileStream fileStream = new FileStream(absolutePath, FileMode.Open, FileAccess.Read);

--- a/SingleDocExtraction/Program.cs
+++ b/SingleDocExtraction/Program.cs
@@ -20,8 +20,7 @@ namespace Examples
             }
 
             IndicoConfig config = new IndicoConfig(
-                host: "app.indico.io",
-                tokenPath: "c:\\Users\\dzere"
+                host: "app.indico.io"
             );
             IndicoClient client = new IndicoClient(config);
 
@@ -30,13 +29,13 @@ namespace Examples
                 args[0]
             };
 
-            JObject json = new JObject()
+            JObject extractConfig = new JObject()
             {
-                { "preset_config", "simple" }
+                { "preset_config", "standard" }
             };
 
             DocumentExtraction extraction = client.DocumentExtraction();
-            List<Job> jobs = extraction.Files(files).JsonConfig(json).Execute();
+            List<Job> jobs = extraction.Files(files).JsonConfig(extractConfig).Execute();
             Job job = jobs[0];
             JObject obj = job.Result().Result;
             string url = (string)obj.GetValue("url");


### PR DESCRIPTION
I just fixed the DocExtraction example and added a default location for IndicoConfig so users could avoid passing in targetPath if they wanted.