### PR TITLE
INT-35 Changed the virtual environment of the CI to windows.

### DIFF
--- a/.github/workflows/Branch build.yml
+++ b/.github/workflows/Branch build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/PR build.yml
+++ b/.github/workflows/PR build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
@addy419 encountered a problem with his PR when he added .Net Framework 4.6.1 to targeted frameworks in the project. CI failed because `dotnet cli` couldn't build this version.

I changed ubuntu-latest to windows-latest, because according to documentation: https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
Windows virtual environment has this targeting pack pre-installed, so the build will work.