### PR TITLE
INT-40 fix coverage (missing assembly name)

### DIFF
--- a/.github/workflows/PR build.yml
+++ b/.github/workflows/PR build.yml
@@ -19,13 +19,15 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory:"./coverage/" --filter FullyQualifiedName\!~IntegrationTests -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+      run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory:"./coverage/" --filter FullyQualifiedName\!~IntegrationTests -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
     - name: Generate report
-      uses: danielpalme/ReportGenerator-GitHub-Action@4.8.4
+      uses: danielpalme/ReportGenerator-GitHub-Action@4.8.5
       with:
         targetdir: ./coverage/
         reporttypes: lcov
-        reports: ./coverage/*/coverage.info
+        reports: ./coverage/*/coverage.*
+        # remove old lib as it's untestable and breaks github coverage report (it's to long for github comment)
+        # assemblyFilters: -/Indico/*
     - name: Post code coverage report
       uses: romeovs/lcov-reporter-action@v0.2.16
       with:


### PR DESCRIPTION
changing lcov -> opencover fixes filtering by assemblyname.