### PR TITLE
INT-128 submission result when failed

### DIFF
--- a/IndicoV2.Abstractions/Extensions/SubmissionResult/Exceptions/WrongSubmissionStatusException.cs
+++ b/IndicoV2.Abstractions/Extensions/SubmissionResult/Exceptions/WrongSubmissionStatusException.cs
@@ -1,19 +1,17 @@
 ﻿using System;
+using IndicoV2.Submissions.Models;
 
 namespace IndicoV2.Extensions.SubmissionResult.Exceptions
 {
+    /// <summary>
+    /// Thrown when trying to get submission result and because of wrong status result cannot be downloaded.
+    /// </summary>
     public class WrongSubmissionStatusException : Exception
     {
-        public WrongSubmissionStatusException()
-        {
-        }
+        public WrongSubmissionStatusException() { }
 
-        public WrongSubmissionStatusException(string message) : base(message)
-        {
-        }
+        public WrongSubmissionStatusException(string message) : base(message) { }
 
-        public WrongSubmissionStatusException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
+        public WrongSubmissionStatusException(SubmissionStatus status) : base($"Cannot get the result because submission status is { status }.") { }
     }
 }

--- a/IndicoV2.Abstractions/Extensions/SubmissionResult/Exceptions/WrongSubmissionStatusException.cs
+++ b/IndicoV2.Abstractions/Extensions/SubmissionResult/Exceptions/WrongSubmissionStatusException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace IndicoV2.Extensions.SubmissionResult.Exceptions
+{
+    public class WrongSubmissionStatusException : Exception
+    {
+        public WrongSubmissionStatusException()
+        {
+        }
+
+        public WrongSubmissionStatusException(string message) : base(message)
+        {
+        }
+
+        public WrongSubmissionStatusException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/IndicoV2/Extensions/SubmissionResult/SubmissionResultAwaiter.cs
+++ b/IndicoV2/Extensions/SubmissionResult/SubmissionResultAwaiter.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using IndicoV2.Extensions.JobResultBuilders;
 using IndicoV2.Extensions.Jobs;
+using IndicoV2.Extensions.SubmissionResult.Exceptions;
 using IndicoV2.Storage;
 using IndicoV2.Submissions;
 using IndicoV2.Submissions.Models;
@@ -27,17 +28,27 @@ namespace IndicoV2.Extensions.SubmissionResult
         }
 
         public async Task<JObject> WaitReady(int submissionId, TimeSpan checkInterval, CancellationToken cancellationToken)
-            => await WaitReady(s => s != SubmissionStatus.PROCESSING, submissionId, checkInterval, cancellationToken);
+            => await WaitReady(s => s != SubmissionStatus.PROCESSING && s != SubmissionStatus.FAILED, submissionId, checkInterval, cancellationToken);
 
         public async Task<JObject> WaitReady(int submissionId, SubmissionStatus awaitedStatus, TimeSpan checkInterval = default, CancellationToken cancellationToken = default)
             => await WaitReady(s => s == awaitedStatus, submissionId, checkInterval, cancellationToken);
 
         private async Task<JObject> WaitReady(Predicate<SubmissionStatus> isAwaitedStatus, int submissionId, TimeSpan checkInterval, CancellationToken cancellationToken)
         {
+            if (isAwaitedStatus(SubmissionStatus.PROCESSING) || isAwaitedStatus(SubmissionStatus.FAILED))
+            {
+                throw new ArgumentException($"Wrong awaited status. Cannot get the result when submission status is {SubmissionStatus.PROCESSING} or {SubmissionStatus.FAILED}.");
+            }
+
             ISubmission submission;
 
             while (!isAwaitedStatus((submission = await _submissionsClient.GetAsync(submissionId, cancellationToken)).Status))
             {
+                if (submission.Status == SubmissionStatus.FAILED)
+                {
+                    throw new WrongSubmissionStatusException($"Cannot get the result because submission status is {SubmissionStatus.FAILED}.");
+                }
+
                 await Task.Delay(checkInterval, cancellationToken);
             }
 

--- a/IndicoV2/Extensions/SubmissionResult/SubmissionResultAwaiter.cs
+++ b/IndicoV2/Extensions/SubmissionResult/SubmissionResultAwaiter.cs
@@ -46,7 +46,7 @@ namespace IndicoV2.Extensions.SubmissionResult
             {
                 if (submission.Status == SubmissionStatus.FAILED)
                 {
-                    throw new WrongSubmissionStatusException($"Cannot get the result because submission status is {SubmissionStatus.FAILED}.");
+                    throw new WrongSubmissionStatusException(SubmissionStatus.FAILED);
                 }
 
                 await Task.Delay(checkInterval, cancellationToken);


### PR DESCRIPTION
I added some guard clauses to the `SubmissionResultAwaiter`.
First of all if `Submission` has status `FAILED`, there is no result file, so we throw exception if this status is returned.
You can pass awaited status to the method - I forbid using `PROCESSING` and `FAILED` because it messes the logic, so I also added the exception if someone wants to wait for one of the two statuses (which actually makes no sense).