### PR TITLE
INT-153 move ClientLib to gitlab

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "4.8.9",
+      "commands": [
+        "reportgenerator"
+      ]
+    }
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docfx.sh text eol=lf

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,12 +8,10 @@ stages:
   - build
   - test
 
-# cache:
-#   key: '$CI_COMMIT_REF_SLUG'
-#   paths:
-#     - '$NUGET_FOLDER'
-#     - '**/obj/'
-#     - '**/bin/'
+cache:
+  key: 'nuget'
+  paths:
+    - '$NUGET_FOLDER'
 
 build:
   stage: build
@@ -21,7 +19,9 @@ build:
     - dotnet restore --packages $NUGET_FOLDER
     - dotnet build --no-restore -c $BUILD_CONF --source $NUGET_FOLDER
   artifacts:
-    untracked: true
+    paths:
+      - '**/bin/'
+      - '**/obj/'
     expire_in: 30 min
 
 test:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: mcr.microsoft.com/dotnet/sdk:5.0
+image: mcr.microsoft.com/dotnet/sdk:5.0.301-alpine3.13-amd64
 
 variables:
   BUILD_CONF: 'Release'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,7 @@
-image: mcr.microsoft.com/dotnet/sdk:5.0.301-alpine3.13-amd64
+# for devel branch:
+# image: mcr.microsoft.com/dotnet/sdk:5.0.301-alpine3.13-amd64
+# for master branch
+image: mcr.microsoft.com/dotnet/sdk:3.1.410-alpine3.13
 
 variables:
   BUILD_CONF: Release
@@ -17,6 +20,7 @@ cache: &global_cache
     - $NUGET_FOLDER
 
 build:
+  except: [tags]
   stage: build
   script:
     - dotnet restore --packages $NUGET_FOLDER
@@ -30,6 +34,7 @@ build:
     expire_in: 5 days
 
 test:
+  except: [tags]
   stage: test
   needs: [build]
   dependencies: [build]
@@ -52,6 +57,7 @@ deploy:
   only: [master, develop]
   stage: deploy
   when: manual
+  allow_failure: false
   needs: [build, test]
   dependencies: [build]
   script:
@@ -59,6 +65,7 @@ deploy:
   cache: {}
 
 build-pages:
+  except: [tags]
   stage: build
   image: managedcode/docfx-automation
   cache: {}
@@ -66,7 +73,7 @@ build-pages:
     - ./docfx_project/docfx.sh build
   artifacts:
     paths:
-    - ./docfx_project/_site
+      - ./docfx_project/_site
     expire_in: 5 days
 
 pages:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,10 +27,11 @@ build:
 test:
   stage: test
   script:
-    - dotnet test --no-restore --no-build -c $BUILD_CONF --verbosity normal --collect:'XPlat Code Coverage' --results-directory:'./coverage/' --filter FullyQualifiedName\!~IntegrationTests -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
+    - dotnet test --no-build --no-restore -c Release --results-directory:'./artifacts/test/' --logger:"junit;LogFileName=./results/{assembly}-test-result.xml" --collect:'XPlat Code Coverage' --filter FullyQualifiedName\!~IntegrationTests -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura 
   artifacts:
     reports:
-      cobertura: coverage/*/coverage.cobertura.xml
+      junit: ./artifacts/test/results/*
+      cobertura: ./artifacts/test/*/coverage.cobertura.xml
   needs: [ 'build' ]
   dependencies: [ build]
     

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,15 +20,18 @@ build:
   script:
     - dotnet restore --packages $NUGET_FOLDER
     - dotnet build --no-restore -c $BUILD_CONF --source $NUGET_FOLDER
-    - dotnet pack --no-build -c $BUILD_CONF ./IndicoV2/IndicoV2.csproj
   artifacts:
     paths:
       - "**/bin/"
       - "**/obj/"
-    expire_in: 5 days
+    expire_in: 30 minutes
 
 test:
   stage: test
+  needs: [build]
+  dependencies: [build]
+  cache:
+    policy: pull
   script:
     # - dotnet clean Indico.Tests/Indico.Tests.csproj -c $BUILD_CONF
     - dotnet test --no-build --no-restore -c $BUILD_CONF --results-directory:'./artifacts/test/' --logger:"junit;LogFileName=./results/{assembly}-test-result.xml" --collect:'XPlat Code Coverage' --filter FullyQualifiedName\!~IntegrationTests -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
@@ -41,14 +44,26 @@ test:
     reports:
       junit: ./artifacts/test/results/*
       cobertura: ./artifacts/test/coverage/Cobertura-fixed.xml
-  needs: [build]
-  dependencies: [build]
 
-deploy:
+build:nuget:
+  stage: build
+  dependencies: [build]
+  cache:
+    policy: pull
+  script:
+    - dotnet pack --no-build -c $BUILD_CONF ./IndicoV2/IndicoV2.csproj -o ./artifacts/nuget/
+  artifacts:
+    paths:
+      - ./artifacts/nuget/
+    expire_in: 5 days
+
+deploy:nuget:
   stage: deploy
   when: manual
   # only: [master]
-  needs: [build, test]
-  dependencies: [build]
+  needs: [build:nuget, test]
+  dependencies: [build:nuget]
   script:
     - dotnet push /IndicoV2/bin/$BUILD_CONF/IndicoClient.*.nupkg  -s https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+  cache:
+    policy: pull

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,46 @@
+image: mcr.microsoft.com/dotnet/sdk:5.0
+
+variables:
+  BUILD_CONF: 'Release'
+  NUGET_FOLDER: './nuget'
+
+stages:
+  - build
+  - test
+
+# cache:
+#   key: '$CI_COMMIT_REF_SLUG'
+#   paths:
+#     - '$NUGET_FOLDER'
+#     - '**/obj/'
+#     - '**/bin/'
+
+build:
+  stage: build
+  script:
+    - dotnet restore --packages $NUGET_FOLDER
+    - dotnet build --no-restore -c $BUILD_CONF --source $NUGET_FOLDER
+  artifacts:
+    untracked: true
+    expire_in: 30 min
+
+test:
+  stage: test
+  script:
+    - dotnet test --no-restore --no-build -c $BUILD_CONF --verbosity normal --collect:'XPlat Code Coverage' --results-directory:'./coverage/' --filter FullyQualifiedName\!~IntegrationTests -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
+  artifacts:
+    reports:
+      cobertura: coverage/*/coverage.cobertura.xml
+  needs: [ 'build' ]
+  dependencies: [ build]
+    
+
+# release:
+#   stage: release
+#   only:
+#     - master
+#   artifacts:
+#     paths:
+#       - publish/
+#   script:
+#     - dotnet publish -c Release -o ../publish ./IndicoV2/IndicoV2.csproj

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,28 +1,31 @@
 image: mcr.microsoft.com/dotnet/sdk:5.0.301-alpine3.13-amd64
 
 variables:
-  BUILD_CONF: 'Release'
-  NUGET_FOLDER: './nuget'
+  BUILD_CONF: "Release"
+  NUGET_FOLDER: "./nuget"
+  BuildType: V2
 
 stages:
   - build
   - test
+  - deploy
 
 cache:
-  key: 'nuget'
+  key: "nuget"
   paths:
-    - '$NUGET_FOLDER'
+    - "$NUGET_FOLDER"
 
 build:
   stage: build
   script:
     - dotnet restore --packages $NUGET_FOLDER
     - dotnet build --no-restore -c $BUILD_CONF --source $NUGET_FOLDER
+    - dotnet pack --no-build -c $BUILD_CONF ./IndicoV2/IndicoV2.csproj
   artifacts:
     paths:
-      - '**/bin/'
-      - '**/obj/'
-    expire_in: 30 min
+      - "**/bin/"
+      - "**/obj/"
+    expire_in: 5 days
 
 test:
   stage: test
@@ -38,16 +41,14 @@ test:
     reports:
       junit: ./artifacts/test/results/*
       cobertura: ./artifacts/test/coverage/Cobertura-fixed.xml
-  needs: [ 'build' ]
-  dependencies: [ build]
-    
+  needs: [build]
+  dependencies: [build]
 
-# release:
-#   stage: release
-#   only:
-#     - master
-#   artifacts:
-#     paths:
-#       - publish/
-#   script:
-#     - dotnet publish -c Release -o ../publish ./IndicoV2/IndicoV2.csproj
+deploy:
+  stage: deploy
+  when: manual
+  # only: [master]
+  needs: [build, test]
+  dependencies: [build]
+  script:
+    - dotnet push /IndicoV2/bin/$BUILD_CONF/IndicoClient.*.nupkg  -s https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,8 @@
 image: mcr.microsoft.com/dotnet/sdk:5.0.301-alpine3.13-amd64
 
 variables:
-  BUILD_CONF: "Release"
-  NUGET_FOLDER: "./nuget"
+  BUILD_CONF: Release
+  NUGET_FOLDER: ./nuget
   BuildType: V2
 
 stages:
@@ -10,30 +10,32 @@ stages:
   - test
   - deploy
 
-cache:
-  key: "nuget"
+cache: &global_cache
+  key: nuget
   paths:
-    - "$NUGET_FOLDER"
+    - $NUGET_FOLDER
 
 build:
   stage: build
   script:
     - dotnet restore --packages $NUGET_FOLDER
     - dotnet build --no-restore -c $BUILD_CONF --source $NUGET_FOLDER
+    - dotnet pack --no-build -c $BUILD_CONF ./IndicoV2/IndicoV2.csproj -o ./artifacts/nuget/
   artifacts:
     paths:
       - "**/bin/"
       - "**/obj/"
-    expire_in: 30 minutes
+      - "./artifacts/nuget/"
+    expire_in: 5 days
 
 test:
   stage: test
   needs: [build]
   dependencies: [build]
   cache:
+    <<: *global_cache
     policy: pull
   script:
-    # - dotnet clean Indico.Tests/Indico.Tests.csproj -c $BUILD_CONF
     - dotnet test --no-build --no-restore -c $BUILD_CONF --results-directory:'./artifacts/test/' --logger:"junit;LogFileName=./results/{assembly}-test-result.xml" --collect:'XPlat Code Coverage' --filter FullyQualifiedName\!~IntegrationTests -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
     - dotnet tool restore
     - dotnet reportgenerator -reports:./artifacts/test/*/coverage.cobertura.xml -targetdir:./artifacts/test/coverage/ -assemblyFilters:-Indicore -sourcedirs:$PWD -reporttypes:cobertura\;TextSummary
@@ -45,25 +47,12 @@ test:
       junit: ./artifacts/test/results/*
       cobertura: ./artifacts/test/coverage/Cobertura-fixed.xml
 
-build:nuget:
-  stage: build
-  dependencies: [build]
-  cache:
-    policy: pull
-  script:
-    - dotnet pack --no-build -c $BUILD_CONF ./IndicoV2/IndicoV2.csproj -o ./artifacts/nuget/
-  artifacts:
-    paths:
-      - ./artifacts/nuget/
-    expire_in: 5 days
-
-deploy:nuget:
+deploy:
   stage: deploy
-  when: manual
+  when: [manual, on_success]
   # only: [master]
-  needs: [build:nuget, test]
-  dependencies: [build:nuget]
+  needs: [build, test]
+  dependencies: [build]
   script:
     - dotnet push /IndicoV2/bin/$BUILD_CONF/IndicoClient.*.nupkg  -s https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
-  cache:
-    policy: pull
+  cache: {}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,3 +56,26 @@ deploy:
   script:
     - dotnet nuget push ./artifacts/nuget/IndicoClient.*.nupkg  -s https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY
   cache: {}
+
+build-pages:
+  stage: build
+  cache: {}
+  script:
+    - ./docfx_project/docfx.sh build
+  artifacts:
+    paths:
+    - ./docfx_project/_site
+    expire_in: 5 days
+
+pages:
+  stage: deploy
+  when: manual
+  # only: [master]
+  needs: [build-pages]
+  dependencies: [build-pages]
+  cache: {}
+  script:
+    - mv ./docfx_project/_site ./public
+  artifacts:
+    paths:
+      - public

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ stages:
   - build
   - test
   - deploy
+  - post-deploy
 
 cache: &global_cache
   key: nuget
@@ -48,18 +49,18 @@ test:
       cobertura: ./artifacts/test/coverage/Cobertura-fixed.xml
 
 deploy:
+  only: [master, develop]
   stage: deploy
   when: manual
-  only: [master, develop]
   needs: [build, test]
   dependencies: [build]
   script:
-    - dotnet nuget push ./artifacts/nuget/IndicoClient.*.nupkg  -s https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY
+    - dotnet nuget push ./artifacts/nuget/IndicoClient.*.nupkg  -s https://api.nuget.org/v3/index.json --api-key $NUGET_KEY
   cache: {}
 
 build-pages:
-  image: managedcode/docfx-automation
   stage: build
+  image: managedcode/docfx-automation
   cache: {}
   script:
     - ./docfx_project/docfx.sh build
@@ -69,10 +70,9 @@ build-pages:
     expire_in: 5 days
 
 pages:
-  stage: deploy
-  when: manual
-  # only: [master]
-  needs: [build-pages]
+  only: [master, develop]
+  stage: post-deploy
+  needs: [deploy, build-pages]
   dependencies: [build-pages]
   cache: {}
   script:
@@ -80,3 +80,21 @@ pages:
   artifacts:
     paths:
       - public
+
+release:
+  only: [master, develop]
+  stage: post-deploy
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  dependencies: [build]
+  needs: [build, deploy]
+  cache: {}
+  script:
+    - VERSION=$(ls ./artifacts/nuget/IndicoClient.*.nupkg | grep -o -E '[[:digit:]]+(.[[:digit:]]+){2}(-[[:alpha:]]+)?.[[:digit:]]+' )
+    - "echo Creating GitLab realease for version $VERSION"
+    - >
+      release-cli create 
+      --tag-name "v$VERSION"
+      --name "IndicoClient v$VERSION"
+      --description "IndicoClient v$VERSION"
+      --assets-link "{ \"name\": \"Nuget file\", \"url\": \"https://www.nuget.org/packages/IndicoClient/$VERSION\" }"
+      --ref $CI_COMMIT_SHA

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,11 +27,17 @@ build:
 test:
   stage: test
   script:
-    - dotnet test --no-build --no-restore -c Release --results-directory:'./artifacts/test/' --logger:"junit;LogFileName=./results/{assembly}-test-result.xml" --collect:'XPlat Code Coverage' --filter FullyQualifiedName\!~IntegrationTests -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura 
+    # - dotnet clean Indico.Tests/Indico.Tests.csproj -c $BUILD_CONF
+    - dotnet test --no-build --no-restore -c $BUILD_CONF --results-directory:'./artifacts/test/' --logger:"junit;LogFileName=./results/{assembly}-test-result.xml" --collect:'XPlat Code Coverage' --filter FullyQualifiedName\!~IntegrationTests -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
+    - dotnet tool restore
+    - dotnet reportgenerator -reports:./artifacts/test/*/coverage.cobertura.xml -targetdir:./artifacts/test/coverage/ -assemblyFilters:-Indicore -sourcedirs:$PWD -reporttypes:cobertura\;TextSummary
+    # fix filename (absolute -> relative path)
+    - cat ./artifacts/test/coverage/Cobertura.xml | sed "s/filename=\"$(pwd -P | sed -e 's/\//\\\//g')\//filename=\"/g" > ./artifacts/test/coverage/Cobertura-fixed.xml
+    - cat ./artifacts/test/coverage/Summary.txt
   artifacts:
     reports:
       junit: ./artifacts/test/results/*
-      cobertura: ./artifacts/test/*/coverage.cobertura.xml
+      cobertura: ./artifacts/test/coverage/Cobertura-fixed.xml
   needs: [ 'build' ]
   dependencies: [ build]
     

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,7 @@ deploy:
   cache: {}
 
 build-pages:
+  image: managedcode/docfx-automation
   stage: build
   cache: {}
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,10 +49,10 @@ test:
 
 deploy:
   stage: deploy
-  when: [manual, on_success]
-  # only: [master]
+  when: manual
+  only: [master, develop]
   needs: [build, test]
   dependencies: [build]
   script:
-    - dotnet push /IndicoV2/bin/$BUILD_CONF/IndicoClient.*.nupkg  -s https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+    - dotnet nuget push ./artifacts/nuget/IndicoClient.*.nupkg  -s https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY
   cache: {}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,16 @@
 <Project>
 
 	<Import Project="../Directory.Build.props" Condition="Exists('../Directory.Build.Props')" />
+
 	<ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
 		<PackageReference Include="coverlet.collector" Version="3.0.3" >
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="JunitXml.TestLogger" Version="3.0.98" >
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
+	
 </Project>

--- a/IndicoV2/IndicoV2.csproj
+++ b/IndicoV2/IndicoV2.csproj
@@ -9,7 +9,7 @@
 
 	<PropertyGroup Condition="'$(BuildType)' == 'V2'">
 		<AssemblyVersion>2.0.0</AssemblyVersion>
-		<Version Condition="'$(Version)' == ''">2.0.0.$([System.DateTime]::UtcNow.ToString(MMddHHmm))</Version>
+		<Version Condition="'$(Version)' == ''">$(AssemblyVersion)-preview.$([System.DateTime]::UtcNow.ToString(yyMMddHHmm))</Version>
 		<TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeP2POutput</TargetsForTfmSpecificBuildOutput>
 	</PropertyGroup>
 

--- a/docfx_project/.gitattributes
+++ b/docfx_project/.gitattributes
@@ -1,1 +1,0 @@
-docfx.sh eol=LF

--- a/docfx_project/docfx.sh
+++ b/docfx_project/docfx.sh
@@ -6,9 +6,7 @@ else
     PARAMS="$1 $2 $3"
 fi
 
-NUGET="./nuget"
-DOCFX="$NUGET/docfx.console/2.58.0/tools/docfx.exe DocFx.json $PARAMS"
+DOCFX="docfx docfx.json $PARAMS"
 
 cd docfx_project
-dotnet restore --packages $NUGET
 $DOCFX

--- a/docfx_project/docfx.sh
+++ b/docfx_project/docfx.sh
@@ -1,12 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
-if [[ $# -eq 0 ]]; then
+if [ $# -eq 0 ]; then
     PARAMS="--serve"
 else
     PARAMS="$1 $2 $3"
 fi
 
-DOCFX="$HOME/.nuget/packages/docfx.console/2.56.6/tools/docfx.exe DocFx.json $PARAMS"
+NUGET="./nuget"
+DOCFX="$NUGET/docfx.console/2.58.0/tools/docfx.exe DocFx.json $PARAMS"
 
-dotnet restore
+cd docfx_project
+dotnet restore --packages $NUGET
 $DOCFX

--- a/docfx_project/docfx_project.csproj
+++ b/docfx_project/docfx_project.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="docfx.console" Version="2.56.6">
+    <PackageReference Include="docfx.console" Version="2.58.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Requires proper NUGET_KEY to be set (details on jira):
sample run: https://gitlab.com/indico1/indico-client-csharp/-/pipelines/326074396 

difference from github pipeline:
- deploy is a manual job, just click run on `deploy` after merge request is merged to master/develop and proper nuget will be pushed to nuget.org
- version number is generated based on `IndicoV2.csproj` + build time (`yyMMddHHmm`). For master it's something like:  `v2.0.0.2106231516`, and for develop branch it should be something like `v2.0.1-preview.2106231516`
- gitlab release + git tag is being created after that