### PR TITLE
[CAT-455] don't lose the port when calling legacy calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ test-results/
 
 IndicoV2.StrawberryShake/Generated/
 user.runsettings
+/IndicoV2/Properties/PublishProfiles
+/Indico/Properties/PublishProfiles

--- a/Indico/Indico.xml
+++ b/Indico/Indico.xml
@@ -161,7 +161,7 @@
             </summary>
             <value>The API token.</value>
         </member>
-        <member name="M:Indico.IndicoConfig.#ctor(System.String,System.String,System.String,System.String,System.Boolean)">
+        <member name="M:Indico.IndicoConfig.#ctor(System.String,System.String,System.Int32,System.String,System.String,System.Boolean)">
             <summary>
             Indico Client config constructor
             </summary>

--- a/Indico/IndicoClient.cs
+++ b/Indico/IndicoClient.cs
@@ -52,7 +52,7 @@ namespace Indico
 
             var handler = GetHandler();
             HttpClient = new HttpClient(handler);
-            string endpoint = $"{Config.Protocol}://{Config.Host}";
+            string endpoint = Config.GetAppBaseUrl();
             var options = new GraphQLHttpClientOptions
             {
                 EndPoint = new System.Uri($"{endpoint}/graph/api/graphql"),

--- a/Indico/IndicoConfig.cs
+++ b/Indico/IndicoConfig.cs
@@ -18,6 +18,10 @@ namespace Indico
         /// </summary>
         /// <value>The host.</value>
         public string Host { get; }
+        /// <summary>
+        /// The port of the url.
+        /// </summary>
+        public int? Port { get; }
 
         /// <summary>
         /// Gets the protocol.
@@ -43,6 +47,7 @@ namespace Indico
         public IndicoConfig(
             [Optional] string apiToken,
             [Optional] string tokenPath,
+            [Optional] int port,
             string host = "app.indico.io",
             string protocol = "https",
             bool verify = true
@@ -50,6 +55,7 @@ namespace Indico
         {
             Host = host;
             Protocol = protocol;
+            Port = port;
             Verify = verify;
             if (apiToken == null)
             {
@@ -96,6 +102,6 @@ namespace Indico
         /// Get the base URL for the Indico Platform host, including protocol
         /// </summary>
         /// <returns>base URL string</returns>
-        public string GetAppBaseUrl() => Protocol + "://" + Host;
+        public string GetAppBaseUrl() => Protocol + "://" + Host + (Port.HasValue? $":{Port.Value}" : "");
     }
 }

--- a/IndicoV2/IndicoClient.cs
+++ b/IndicoV2/IndicoClient.cs
@@ -23,7 +23,7 @@ namespace IndicoV2
 
         internal Indico.IndicoClient LegacyClient =>
             _legacyClient ?? (_legacyClient =
-                new Indico.IndicoClient(new IndicoConfig(host: BaseUri.Host, apiToken: _apiToken, verify: _verifySsl)));
+                new Indico.IndicoClient(new IndicoConfig(host: BaseUri.Host, port: BaseUri.Port, apiToken: _apiToken, verify: _verifySsl)));
 
         private IndicoStrawberryShakeClient _indicoStrawberryShakeClient;
 


### PR DESCRIPTION
Passes the port all the way down to the legacy graphql client...