### PR TITLE
[CAT-626] Get workflow, dataset and model ids from env vars

### DIFF
--- a/IndicoV2.IntegrationTests/Models/ModelClientTests.cs
+++ b/IndicoV2.IntegrationTests/Models/ModelClientTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using IndicoV2.DataSets;
 using IndicoV2.Extensions.Jobs;
 using IndicoV2.IntegrationTests.Utils;
+using IndicoV2.IntegrationTests.Utils.Configs;
 using IndicoV2.Models;
 using NUnit.Framework;
 using Unity;
@@ -18,15 +19,27 @@ namespace IndicoV2.IntegrationTests.Models
         private int _modelGroupId;
         private IJobAwaiter _jobAwaiter;
         private int _modelId;
+        private IndicoConfigs _indicoConfigs;
 
         [OneTimeSetUp]
         public async Task SetUp()
         {
-            var container = new IndicoTestContainerBuilder().Build();
+            var containerBuilder = new IndicoTestContainerBuilder();
+            var container = containerBuilder.Build();
 
             _modelClient = container.Resolve<IModelClient>();
+            _indicoConfigs = new IndicoConfigs();
             var dataSets = await container.Resolve<IDataSetClient>().ListFullAsync(1);
-            _modelGroupId = dataSets.First().ModelGroups.First().Id;
+            _indicoConfigs = new IndicoConfigs();
+            var _rawModelGroupId = _indicoConfigs.ModelGroupId;
+            if (_rawModelGroupId == 0)
+            {
+                _modelGroupId = dataSets.First().ModelGroups.First().Id;
+            }
+            else
+            {
+                _modelGroupId = _rawModelGroupId;
+            }
             _modelId = (await _modelClient.GetGroup(_modelGroupId, default)).Id;
             _jobAwaiter = container.Resolve<IJobAwaiter>();
         }

--- a/IndicoV2.IntegrationTests/Utils/Configs/IndicoConfigs.cs
+++ b/IndicoV2.IntegrationTests/Utils/Configs/IndicoConfigs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace IndicoV2.IntegrationTests.Utils.Configs
+{
+    internal class IndicoConfigs
+    {
+        public int WorkflowId => ParseEnvVar("INDICO_TEST_WORKFLOW_ID");
+
+        public int DatasetId => ParseEnvVar("INDICO_TEST_DATASET_ID");
+
+        public int ModelGroupId => ParseEnvVar("INDICO_TEST_MODELGROUP_ID");
+
+        public static int ParseEnvVar(string varName)
+        {
+            var rawValue = Environment.GetEnvironmentVariable(varName);
+            if (!string.IsNullOrEmpty(rawValue))
+            {
+                int.TryParse(rawValue, out var _intId);
+                return _intId;
+            }
+            return 0;
+        }
+    }
+}

--- a/IndicoV2.IntegrationTests/Utils/DataHelpers/DataHelper.cs
+++ b/IndicoV2.IntegrationTests/Utils/DataHelpers/DataHelper.cs
@@ -1,4 +1,5 @@
-﻿using IndicoV2.IntegrationTests.Utils.DataHelpers.DataSets;
+﻿using System;
+using IndicoV2.IntegrationTests.Utils.DataHelpers.DataSets;
 using IndicoV2.IntegrationTests.Utils.DataHelpers.Files;
 using IndicoV2.IntegrationTests.Utils.DataHelpers.Submissions;
 using IndicoV2.IntegrationTests.Utils.DataHelpers.Uris;
@@ -22,5 +23,6 @@ namespace IndicoV2.IntegrationTests.Utils.DataHelpers
         public UriHelper Uris() => _container.Resolve<UriHelper>();
 
         public DataSetHelper DataSets() => _container.Resolve<DataSetHelper>();
+
     }
 }

--- a/IndicoV2.IntegrationTests/Utils/DataHelpers/DataSets/DataSetHelper.cs
+++ b/IndicoV2.IntegrationTests/Utils/DataHelpers/DataSets/DataSetHelper.cs
@@ -11,6 +11,5 @@ namespace IndicoV2.IntegrationTests.Utils.DataHelpers.DataSets
 
         public DataSetHelper(IDataSetClient dataSetClient) => _dataSetClient = dataSetClient;
         public async Task<IDataSet> GetAny() => (await _dataSetClient.ListFullAsync(1)).Single();
-
     }
 }

--- a/IndicoV2.IntegrationTests/Utils/DataHelpers/DataSets/DataSetHelper.cs
+++ b/IndicoV2.IntegrationTests/Utils/DataHelpers/DataSets/DataSetHelper.cs
@@ -11,5 +11,6 @@ namespace IndicoV2.IntegrationTests.Utils.DataHelpers.DataSets
 
         public DataSetHelper(IDataSetClient dataSetClient) => _dataSetClient = dataSetClient;
         public async Task<IDataSet> GetAny() => (await _dataSetClient.ListFullAsync(1)).Single();
+
     }
 }

--- a/IndicoV2.IntegrationTests/Utils/IndicoTestContainerBuilder.cs
+++ b/IndicoV2.IntegrationTests/Utils/IndicoTestContainerBuilder.cs
@@ -23,7 +23,22 @@ namespace IndicoV2.IntegrationTests.Utils
         private string BaseUrl => Environment.GetEnvironmentVariable("INDICO_HOST");
         private string ApiToken => Environment.GetEnvironmentVariable("INDICO_TOKEN");
 
+        public int WorkflowId => ParseEnvVar("INDICO_TEST_WORKFLOW_ID");
 
+        public int DatasetId => ParseEnvVar("INDICO_TEST_DATASET_ID");
+
+        public int ModelGroupId => ParseEnvVar("INDICO_TEST_MODELGROUP_ID");
+
+        public static int ParseEnvVar(string varName)
+        {
+            string rawValue = Environment.GetEnvironmentVariable(varName);
+            if (!string.IsNullOrEmpty(rawValue))
+            {
+                int.TryParse(rawValue, out int _intId);
+                return _intId;
+            }
+            return 0;
+        }
         public IndicoTestContainerBuilder() => _container = new UnityContainer();
 
 
@@ -37,7 +52,7 @@ namespace IndicoV2.IntegrationTests.Utils
             }
 
             _container.RegisterType<IIndicoClient, IndicoClient>();
-            
+
             _container.RegisterFactory<IDataSetClient>(c => c.Resolve<IndicoClient>().DataSets());
             _container.RegisterFactory<IWorkflowsClient>(c => c.Resolve<IndicoClient>().Workflows());
             _container.RegisterFactory<ISubmissionsClient>(c => c.Resolve<IndicoClient>().Submissions());

--- a/IndicoV2.IntegrationTests/Utils/IndicoTestContainerBuilder.cs
+++ b/IndicoV2.IntegrationTests/Utils/IndicoTestContainerBuilder.cs
@@ -23,22 +23,7 @@ namespace IndicoV2.IntegrationTests.Utils
         private string BaseUrl => Environment.GetEnvironmentVariable("INDICO_HOST");
         private string ApiToken => Environment.GetEnvironmentVariable("INDICO_TOKEN");
 
-        public int WorkflowId => ParseEnvVar("INDICO_TEST_WORKFLOW_ID");
 
-        public int DatasetId => ParseEnvVar("INDICO_TEST_DATASET_ID");
-
-        public int ModelGroupId => ParseEnvVar("INDICO_TEST_MODELGROUP_ID");
-
-        public static int ParseEnvVar(string varName)
-        {
-            string rawValue = Environment.GetEnvironmentVariable(varName);
-            if (!string.IsNullOrEmpty(rawValue))
-            {
-                int.TryParse(rawValue, out int _intId);
-                return _intId;
-            }
-            return 0;
-        }
         public IndicoTestContainerBuilder() => _container = new UnityContainer();
 
 

--- a/IndicoV2.IntegrationTests/Workflows/WorkflowClientTests.cs
+++ b/IndicoV2.IntegrationTests/Workflows/WorkflowClientTests.cs
@@ -18,32 +18,45 @@ namespace IndicoV2.IntegrationTests.Workflows
         private IndicoConfigs _indicoConfigs;
         private IWorkflowsClient _workflowsClient;
         private int _workflowId;
+        private int _dataSetId;
 
         [SetUp]
         public async Task SetUp()
         {
             var container = new IndicoTestContainerBuilder().Build();
             _dataSetClient = container.Resolve<IDataSetClient>();
-            _workflowsClient = container.Resolve<IWorkflowsClient>();
-            _dataHelper = container.Resolve<DataHelper>();
-            _indicoConfigs = new IndicoConfigs();
-            int _rawWorkflowID = _indicoConfigs.WorkflowId;
-            if (_rawWorkflowID == 0)
+            var _rawDataSetId = _indicoConfigs.DatasetId;
+            if (_rawDataSetId == 0)
             {
-                var workflow = (await _dataHelper.Workflows().GetAnyWorkflow());
-                _workflowId = workflow.Id;
+                var dataset = (await _dataHelper.DataSets().GetAny());
+                _dataSetId = dataset.Id;
+                var workflows = await _workflowsClient.ListAsync(_dataSetId, default);
+                _workflowId = workflows.First().Id;
             }
             else
             {
-                _workflowId = _rawWorkflowID;
+                _dataSetId = _rawDataSetId;
+                int _rawWorkflowID = _indicoConfigs.WorkflowId;
+                if (_rawWorkflowID == 0)
+                {
+                    var workflows = await _workflowsClient.ListAsync(_dataSetId, default);
+                    _workflowId = workflows.First().Id;
+                }
+                else
+                {
+                    _workflowId = _rawWorkflowID;
+                }
             }
+            _workflowsClient = container.Resolve<IWorkflowsClient>();
+            _dataHelper = container.Resolve<DataHelper>();
+            _indicoConfigs = new IndicoConfigs();
         }
 
         [Test]
         public async Task AddData_ShouldReturnResult()
         {
-            var dataSetId = _indicoConfigs.DatasetId;
-            await _dataSetClient.AddFilesAsync(dataSetId, new[] {_dataHelper.Files().GetSampleFilePath()}, default);
+
+            await _dataSetClient.AddFilesAsync(_dataSetId, new[] {_dataHelper.Files().GetSampleFilePath()}, default);
             var result = await _workflowsClient.AddDataAsync(_workflowId, default);
 
             result.Should().NotBeNull();

--- a/IndicoV2.IntegrationTests/Workflows/WorkflowClientTests.cs
+++ b/IndicoV2.IntegrationTests/Workflows/WorkflowClientTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using IndicoV2.DataSets;
 using IndicoV2.IntegrationTests.Utils;
+using IndicoV2.IntegrationTests.Utils.Configs;
 using IndicoV2.IntegrationTests.Utils.DataHelpers;
 using IndicoV2.Workflows;
 using NUnit.Framework;
@@ -14,25 +15,36 @@ namespace IndicoV2.IntegrationTests.Workflows
     {
         private IDataSetClient _dataSetClient;
         private DataHelper _dataHelper;
+        private IndicoConfigs _indicoConfigs;
         private IWorkflowsClient _workflowsClient;
+        private int _workflowId;
 
         [SetUp]
-        public void SetUp()
+        public async Task SetUp()
         {
             var container = new IndicoTestContainerBuilder().Build();
             _dataSetClient = container.Resolve<IDataSetClient>();
             _workflowsClient = container.Resolve<IWorkflowsClient>();
             _dataHelper = container.Resolve<DataHelper>();
+            _indicoConfigs = new IndicoConfigs();
+            int _rawWorkflowID = _indicoConfigs.WorkflowId;
+            if (_rawWorkflowID == 0)
+            {
+                var workflow = (await _dataHelper.Workflows().GetAnyWorkflow());
+                _workflowId = workflow.Id;
+            }
+            else
+            {
+                _workflowId = _rawWorkflowID;
+            }
         }
 
         [Test]
         public async Task AddData_ShouldReturnResult()
         {
-            var dataSet = await _dataHelper.DataSets().GetAny();
-            await _dataSetClient.AddFilesAsync(dataSet.Id, new[] {_dataHelper.Files().GetSampleFilePath()}, default);
-            var workflows = await _workflowsClient.ListAsync(dataSet.Id, default);
-
-            var result = await _workflowsClient.AddDataAsync(workflows.First().Id, default);
+            var dataSetId = _indicoConfigs.DatasetId;
+            await _dataSetClient.AddFilesAsync(dataSetId, new[] {_dataHelper.Files().GetSampleFilePath()}, default);
+            var result = await _workflowsClient.AddDataAsync(_workflowId, default);
 
             result.Should().NotBeNull();
         }

--- a/README.md
+++ b/README.md
@@ -71,3 +71,19 @@ The examples are setup as console apps in the repo's Visual Studio project.
 IndicoConfig config = new IndicoConfig(host: "app.indico.io");
 IndicoClient indico = new IndicoClient(config);
 ```
+
+## Integration Test Setup
+
+### Setting Environment Variables
+It is highly recommended that developers set the following environment variables before
+running the integration tests. 
+
+`INDICO_HOST`: the host of the Indico instance you are testing against. Must include `https://`
+`INDICO_TOKEN`: api token associated with the Indico host
+`INDICO_TEST_WORKFLOW_ID`: Workflow id you are testing against
+`INDICO_TEST_DATASET_ID`: Dataset id you are testing against
+`INDICO_TEST_MODELGROUP_ID`: model group id you are testing against (NOT selected model id)
+
+Notes for ID configs:
+* You will want to ensure that all IDs come from the same dataset, eg the workflow id belongs to the dataset id provided.  
+* If these IDs are not provided, the integration tests will infer them by selecting the first dataset ID available to the user testing. 


### PR DESCRIPTION
We may want to enforce setting ids here. The integration tests for models and workflows rely on the dataset associated with them. We should probably set up a workflow and provide the ids in the README as well as instructions on how to set them. 