### PR TITLE
[CAT-323] deprecreate loadModel

### DIFF
--- a/Indico.Tests/Mutation/ModelGroupLoadTest.cs
+++ b/Indico.Tests/Mutation/ModelGroupLoadTest.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Indico.Tests.Mutation
 {
     [TestClass]
+    [Ignore]
     public class ModelGroupQueryTest
     {
         private GraphQLHttpClient _client;

--- a/Indico/Mutation/ModelGroupLoad.cs
+++ b/Indico/Mutation/ModelGroupLoad.cs
@@ -57,39 +57,6 @@ namespace Indico.Mutation
         /// Executes request and returns load status.  
         /// </summary>
         /// <returns>Load status.</returns>
-        public async Task<string> Exec(CancellationToken cancellationToken = default)
-        {
-            var query = @"
-                    mutation LoadModel($model_id: Int!) {
-                        modelLoad(modelId: $model_id) {
-                            status
-                        }
-                    }
-                ";
-
-            var request = new GraphQLRequest()
-            {
-                Query = query,
-                OperationName = "LoadModel",
-                Variables = new
-                {
-                    model_id = ModelId
-                }
-            };
-
-            var response = await _graphQLHttpClient.SendMutationAsync<dynamic>(request, cancellationToken);
-            if (response.Errors != null)
-            {
-                throw new GraphQLException(response.Errors);
-            }
-
-            var modelLoad = response.Data.modelLoad;
-            if (modelLoad == null)
-            {
-                throw new RuntimeException($"Cannot Load Model id : {ModelId}");
-            }
-
-            return (string)modelLoad.status;
-        }
+        public async Task<string> Exec(CancellationToken cancellationToken = default) => "Success";
     }
 }

--- a/IndicoV2.Abstractions/Models/IModelClient.cs
+++ b/IndicoV2.Abstractions/Models/IModelClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using IndicoV2.Models.Models;
@@ -21,6 +22,7 @@ namespace IndicoV2.Models
         /// <param name="modelId"><seealso cref="IModel"/>'s Id</param>
         /// <param name="cancellationToken"><c><see cref="CancellationToken"/></c> for handling cancellation of asynchronous operations.</param>
         /// <returns>Status</returns>
+        [Obsolete("Models are now automatically loaded by IPA")]
         Task<string> LoadModel(int modelId, CancellationToken cancellationToken);
 
         /// <summary>

--- a/IndicoV2.V1Adapters/Models/V1ModelClientAdapter.cs
+++ b/IndicoV2.V1Adapters/Models/V1ModelClientAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Indico.Mutation;
@@ -21,7 +22,8 @@ namespace IndicoV2.V1Adapters.Models
                 {
                     MgId = modelGroupId
                 }.Exec(cancellationToken));
-
+       
+        [Obsolete("Models are now automatically loaded by IPA")]
         public Task<string> LoadModel(int modelId, CancellationToken cancellationToken) =>
             new ModelGroupLoad(_clientLegacy.GraphQLHttpClient) {ModelId = modelId}.Exec(cancellationToken);
 


### PR DESCRIPTION
Using depreceate on the LoadModel methods instead of deleting them.