### PR TITLE
[CAT-839] Update GetPredictions Examples

### DIFF
--- a/Examples/GetPredictionsBasic/Program.cs
+++ b/Examples/GetPredictionsBasic/Program.cs
@@ -1,9 +1,7 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using IndicoV2;
-using Newtonsoft.Json.Linq;
 
 namespace Examples
 {
@@ -18,23 +16,10 @@ namespace Examples
 
         public static async Task Main()
         {
-            var client = new IndicoClient(GetToken(), new Uri("https://app.indico.io"));
-
-            var submissionClient = client.Submissions();
-
-            var storageClient = client.Storage();
-
-            int submissionId = 152070;
-            var submission = await submissionClient.GetAsync(submissionId);
-
-            string resultFileUrl = submission.ResultFile;
-            var storageResult = await storageClient.GetAsync(new Uri(resultFileUrl), default);
-            using (var reader = new StreamReader(storageResult))
-            {
-                string resultAsString = reader.ReadToEnd();
-                JObject resultObject = JObject.Parse(resultAsString);
-                Console.WriteLine(resultObject);
-            }
+            var client = new IndicoClient(GetToken(), new Uri("https://try.indico.io"));
+            int submissionId = 91345;
+            var jobResult = await client.GetSubmissionResultAwaiter().WaitReady(submissionId);
+            Console.WriteLine(jobResult);
         }
     }
 }

--- a/Examples/GetPredictionsWithReview/Program.cs
+++ b/Examples/GetPredictionsWithReview/Program.cs
@@ -18,18 +18,17 @@ namespace Examples
         public static async Task Main()
         {
             var client = new IndicoClient(GetToken(), new Uri("https://try.indico.io"));
-
             int submissionId = 91345;
 
             string jobId = await client.Submissions().GenerateSubmissionResultAsync(submissionId);
-            JToken jobResult = await client.JobAwaiter().WaitReadyAsync<JToken>(jobId, default, default);
+            var jobResult = await client.JobAwaiter().WaitReadyAsync<JToken>(jobId, default, default);
             string jobResultUrl = jobResult.Value<string>("url");
 
             var storageResult = await client.Storage().GetAsync(new Uri(jobResultUrl), default);
             using (var reader = new StreamReader(storageResult))
             {
                 string resultAsString = reader.ReadToEnd();
-                JObject resultObject = JObject.Parse(resultAsString);
+                var resultObject = JObject.Parse(resultAsString);
                 Console.WriteLine(resultObject);
             }
         }

--- a/Examples/GetPredictionsWithReview/Program.cs
+++ b/Examples/GetPredictionsWithReview/Program.cs
@@ -19,19 +19,13 @@ namespace Examples
         {
             var client = new IndicoClient(GetToken(), new Uri("https://try.indico.io"));
 
-            var submissionClient = client.Submissions();
-
-            var jobClient = client.Jobs();
-
-            var storageClient = client.Storage();
-
             int submissionId = 91345;
 
-            string jobId = await submissionClient.GenerateSubmissionResultAsync(submissionId);
-            JToken jobResult = await jobClient.GetResultAsync<JToken>(jobId);
+            string jobId = await client.Submissions().GenerateSubmissionResultAsync(submissionId);
+            JToken jobResult = await client.JobAwaiter().WaitReadyAsync<JToken>(jobId, default, default);
             string jobResultUrl = jobResult.Value<string>("url");
 
-            var storageResult = await storageClient.GetAsync(new Uri(jobResultUrl), default);
+            var storageResult = await client.Storage().GetAsync(new Uri(jobResultUrl), default);
             using (var reader = new StreamReader(storageResult))
             {
                 string resultAsString = reader.ReadToEnd();

--- a/Examples/GetPredictionsWithReview/Program.cs
+++ b/Examples/GetPredictionsWithReview/Program.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using IndicoV2;
 using Newtonsoft.Json.Linq;
@@ -18,7 +17,7 @@ namespace Examples
 
         public static async Task Main()
         {
-            var client = new IndicoClient(GetToken(), new Uri("https://app.indico.io"));
+            var client = new IndicoClient(GetToken(), new Uri("https://try.indico.io"));
 
             var submissionClient = client.Submissions();
 
@@ -26,8 +25,7 @@ namespace Examples
 
             var storageClient = client.Storage();
 
-            int submissionId = 152070;
-            var submission = await submissionClient.GetAsync(submissionId);
+            int submissionId = 91345;
 
             string jobId = await submissionClient.GenerateSubmissionResultAsync(submissionId);
             JToken jobResult = await jobClient.GetResultAsync<JToken>(jobId);


### PR DESCRIPTION
`SubmissionResultAwaiter` retrieves the result file and only returns final predictions.

GetPredictionsWithReview example queries for the job result instead. I suppose there is an open question on whether we should refactor SubmissionResultAwaiter to be able to retrieve pre_review, post_review, and final predictions