### PR TITLE
[DEV-11466] Fix MarkSubmissionAsRetrieved

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.202
+          dotnet-version: 6.0.0
       - name: Pack
         run: dotnet pack ./IndicoV2/IndicoV2.csproj
       # - name: 'Upload Artifact'
@@ -36,5 +36,4 @@ jobs:
       #     retention-days: 1
       #     if-no-files-found: error
       - name: Push
-        run: dotnet nuget push ${{ env.NugetFile }} -s https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} 
-      
+        run: dotnet nuget push ${{ env.NugetFile }} -s https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/IndicoV2.StrawberryShake/Submissions/Submissions.graphql
+++ b/IndicoV2.StrawberryShake/Submissions/Submissions.graphql
@@ -139,12 +139,63 @@ query GetSubmission($submissionId: Int!) {
     datasetId
     workflowId
     status
+    createdAt
+    updatedAt
+    createdBy
+    updatedBy
+    completedAt
+    errors
+    filesDeleted
+    inputFiles {
+      id
+      filepath
+      filename
+      filetype
+      submissionId
+      fileSize
+      numPages
+    }
     inputFile
     inputFilename
     resultFile
-    deleted
+    outputFiles {
+      id
+      filepath
+      submissionId
+      componentId
+      createdAt
+    }
     retrieved
-    errors
+    autoReview {
+      id
+      submissionId
+      createdAt
+      createdBy
+      startedAt
+      completedAt
+      rejected
+      reviewType
+      notes
+    }
+    retries {
+      id
+      submissionId
+      previousErrors
+      previousStatus
+      retryErrors
+    }
+    reviews {
+      id
+      submissionId
+      createdAt
+      createdBy
+      startedAt
+      completedAt
+      rejected
+      reviewType
+      notes
+    }
+    reviewInProgress
   }
 }
 

--- a/IndicoV2/Submissions/SubmissionsClient.cs
+++ b/IndicoV2/Submissions/SubmissionsClient.cs
@@ -145,12 +145,22 @@ namespace IndicoV2.Submissions
 
         public async Task<ISubmission> MarkSubmissionAsRetrieved(int submissionId, bool retrieved = true, CancellationToken cancellationToken = default)
         {
-            var resultId = await _strawberryShakeClient.Submissions().MarkRetrieved(submissionId, retrieved, cancellationToken);
-            var result = await _strawberryShakeClient.Submissions().List(new List<int?>(submissionId).AsReadOnly(), default, default, default, default, cancellationToken);
-            return new SubmissionSs(result?.Submissions?[0]);
+            await _strawberryShakeClient.Submissions().MarkRetrieved(submissionId, retrieved, cancellationToken);
+            var result = await _strawberryShakeClient.Submissions().Get(submissionId, cancellationToken);
+            return new Submission
+            {
+                Id = result.Id ?? 0,
+                Status = (Models.SubmissionStatus)result.Status,
+                DatasetId = result.DatasetId ?? 0,
+                WorkflowId = result.WorkflowId ?? 0,
+                InputFile = result.InputFile,
+                InputFilename = result.InputFilename,
+                ResultFile = result.ResultFile,
+                Retrieved = result.Retrieved ?? throw new ArgumentException("Invalid value for retrieved received from call"),
+                Errors = result.Errors ?? null
+            };
         }
 
         private ISubmission ToSubmissionFromSs(IListSubmissions_Submissions_Submissions submission) => new SubmissionSs(submission);
-
     }
 }

--- a/IndicoV2/Submissions/SubmissionsClient.cs
+++ b/IndicoV2/Submissions/SubmissionsClient.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using IndicoV2.CommonModels.Pagination;
 using IndicoV2.StrawberryShake;
 using IndicoV2.Submissions.Models;
+using IndicoV2.Reviews.Models;
 using IndicoV2.Storage;
 using Newtonsoft.Json.Linq;
 
@@ -125,18 +126,7 @@ namespace IndicoV2.Submissions
             {
                 throw new NotSupportedException($"Cannot read submission status: {result.Status}");
             }
-            return new Submission
-            {
-                Id = result.Id ?? 0,
-                Status = (Models.SubmissionStatus)result.Status,
-                DatasetId = result.DatasetId ?? 0,
-                WorkflowId = result.WorkflowId ?? 0,
-                InputFile = result.InputFile,
-                InputFilename = result.InputFilename,
-                ResultFile = result.ResultFile,
-                Retrieved = result.Retrieved ?? throw new ArgumentException("Invalid value for retrieved received from call"),
-                Errors = result.Errors ?? null
-            };
+            return GetSubmissionToSubmission(result);
         }
 
 
@@ -147,20 +137,70 @@ namespace IndicoV2.Submissions
         {
             await _strawberryShakeClient.Submissions().MarkRetrieved(submissionId, retrieved, cancellationToken);
             var result = await _strawberryShakeClient.Submissions().Get(submissionId, cancellationToken);
-            return new Submission
-            {
-                Id = result.Id ?? 0,
-                Status = (Models.SubmissionStatus)result.Status,
-                DatasetId = result.DatasetId ?? 0,
-                WorkflowId = result.WorkflowId ?? 0,
-                InputFile = result.InputFile,
-                InputFilename = result.InputFilename,
-                ResultFile = result.ResultFile,
-                Retrieved = result.Retrieved ?? throw new ArgumentException("Invalid value for retrieved received from call"),
-                Errors = result.Errors ?? null
-            };
+            return GetSubmissionToSubmission(result);
         }
 
         private ISubmission ToSubmissionFromSs(IListSubmissions_Submissions_Submissions submission) => new SubmissionSs(submission);
+
+        private ISubmission GetSubmissionToSubmission(IGetSubmission_Submission result) => new Submission
+        {
+            Id = result.Id ?? 0,
+            Status = (Models.SubmissionStatus)result.Status,
+            DatasetId = result.DatasetId ?? 0,
+            WorkflowId = result.WorkflowId ?? 0,
+            CreatedAt = result.CreatedAt,
+            UpdatedAt = result.UpdatedAt,
+            CompletedAt = result.CompletedAt,
+            FilesDeleted = result.FilesDeleted,
+            InputFiles = result.InputFiles.Select(inputFile => new SubmissionFile
+            {
+                Id = inputFile.Id,
+                FilePath = inputFile.Filepath,
+                FileName = inputFile.Filename,
+                FileType = inputFile.Filetype.ToString(),
+                SubmissionId = inputFile.SubmissionId,
+                FileSize = inputFile.FileSize,
+                NumPages = inputFile.NumPages
+            }).ToArray(),
+            InputFile = result.InputFile,
+            InputFilename = result.InputFilename,
+            ResultFile = result.ResultFile,
+            OutputFiles = result.OutputFiles.Select(x => new SubmissionOutput() { }).ToArray(),
+            Retrieved = result.Retrieved ?? throw new ArgumentException("Invalid value for retrieved received from call"),
+            AutoReview = result.AutoReview != null ? new Review
+            {
+                Id = result.AutoReview.Id,
+                SubmissionId = result.AutoReview.SubmissionId,
+                CreatedAt = result.AutoReview.CreatedAt,
+                CreatedBy = result.AutoReview.CreatedBy,
+                StartedAt = result.AutoReview.StartedAt,
+                CompletedAt = result.AutoReview.CompletedAt,
+                Rejected = result.AutoReview.Rejected,
+                ReviewType = (Models.ReviewType)result.AutoReview.ReviewType,
+                Notes = result.AutoReview.Notes,
+            } : new Review() { },
+            Retries = result.Retries.Select(submissionRetry => new SubmissionRetry
+            {
+                Id = submissionRetry.Id,
+                SubmissionId = submissionRetry.SubmissionId,
+                PreviousErrors = submissionRetry.PreviousErrors,
+                PreviousStatus = (Models.SubmissionStatus)submissionRetry.PreviousStatus,
+                RetryErrors = submissionRetry.RetryErrors
+            }).ToArray(),
+            Reviews = result.Reviews.Select(review => new Review
+            {
+                Id = review.Id,
+                SubmissionId = review.SubmissionId,
+                CreatedAt = review.CreatedAt,
+                CreatedBy = review.CreatedBy,
+                StartedAt = review.StartedAt,
+                CompletedAt = review.CompletedAt,
+                Rejected = review.Rejected,
+                ReviewType = (Models.ReviewType)review.ReviewType,
+                Notes = review.Notes,
+            }).ToArray(),
+            ReviewInProgress = result.ReviewInProgress,
+            Errors = result.Errors ?? null
+        };
     }
 }

--- a/Nuget.props
+++ b/Nuget.props
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="6.0" encoding="utf-8" ?>
 <Project>
 
 	<PropertyGroup>
@@ -10,7 +10,7 @@
 		<RepositoryUrl>https://github.com/IndicoDataSolutions/indico-client-csharp</RepositoryUrl>
 		<RepositoryType>Github</RepositoryType>
 		<PackageTags>Indico</PackageTags>
-		<PackageReleaseNotes>This is the 4.x IPA platform package.</PackageReleaseNotes>
+		<PackageReleaseNotes>This is the 6.x IPA platform package.</PackageReleaseNotes>
 		<Product>Indico IPA</Product>
 		<Copyright>$([System.DateTime]::UtcNow.ToString("YYYY)) Indico, Inc.</Copyright>
 		<NeutralLanguage>en-US</NeutralLanguage>

--- a/Nuget.props
+++ b/Nuget.props
@@ -1,4 +1,4 @@
-<?xml version="6.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Project>
 
 	<PropertyGroup>


### PR DESCRIPTION
- Fix MarkSubmissionRetrieved Lag by using GetAsync instead of ListAsync
- Update dotnet version to 6.0
- Update GetSubmission call to match ListSubmissions in returning full Submission data from GraphQL call